### PR TITLE
URL Cleanup

### DIFF
--- a/test/springpythontest/support/contextSpringJavaAppContext.xml
+++ b/test/springpythontest/support/contextSpringJavaAppContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+           https://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
 	<bean id="MovieLister" class="springpythontest.support.testSupportClasses.MovieLister" scope="prototype">
 		<property name="finder" ref="MovieFinder"/>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://springpython.webfactional.com/schema/context/spring-python-context-1.0.xsd (404) with 35 occurrences could not be migrated:  
   ([https](https://springpython.webfactional.com/schema/context/spring-python-context-1.0.xsd) result SSLHandshakeException).
* http://springpython.webfactional.com/schema/context/spring-python-context-1.1.xsd (404) with 11 occurrences could not be migrated:  
   ([https](https://springpython.webfactional.com/schema/context/spring-python-context-1.1.xsd) result SSLHandshakeException).
* http://springpython.webfactional.com/schema/context/spring-python-pycontainer-context-1.0.xsd (404) with 8 occurrences could not be migrated:  
   ([https](https://springpython.webfactional.com/schema/context/spring-python-pycontainer-context-1.0.xsd) result SSLHandshakeException).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.springframework.org/schema/beans/spring-beans-2.5.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-2.5.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-2.5.xsd) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080/ with 1 occurrences
* http://www.springframework.org/schema/beans with 2 occurrences
* http://www.springframework.org/springpython/schema/objects with 70 occurrences
* http://www.springframework.org/springpython/schema/objects/1.1 with 22 occurrences
* http://www.springframework.org/springpython/schema/pycontainer-components with 16 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 55 occurrences