### PR TITLE
URL Cleanup

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-   Copyright 2006-2011 SpringSource (http://springsource.com), All Rights Reserved 
+   Copyright 2006-2011 SpringSource (https://springsource.com), All Rights Reserved 
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ def usage():
     print "\t--package\t\tpackage everything up into a tarball for release to sourceforge in %s" % p["packageDir"]
     print "\t--build-stamp [tag]\tfor --package, this specifies a special tag, generating version tag '%s.<tag>. springpython.properties can override with build.stamp'" % p["version"]
     print "\t\t\t\tIf this option isn't used, default will be tag will be '%s.<current time>'" % p["version"]
-    print "\t--register\t\tregister this release with http://pypi.python.org/pypi"
+    print "\t--register\t\tregister this release with https://pypi.python.org/pypi"
     print "\t--docs-sphinx\t\tgenerate Sphinx documentation"
     print "\t--pydoc\t\t\tgenerate pydoc information"
     print

--- a/docs/sphinx/source/dao.rst
+++ b/docs/sphinx/source/dao.rst
@@ -19,27 +19,27 @@ SQL databases. Depending on which SQL connection factory you're about to use,
 you need to install following dependencies:
 
 * *springpython.database.factory.MySQLConnectionFactory* -
-  needs `MySQLdb <http://sourceforge.net/projects/mysql-python/>`_ for connecting to MySQL,
+  needs `MySQLdb <https://sourceforge.net/projects/mysql-python/>`_ for connecting to MySQL,
 
 * *springpython.database.factory.PgdbConnectionFactory* -
   needs `PyGreSQL <http://www.pygresql.org/>`_ for connecting to PostgreSQL,
 
 * *springpython.database.factory.Sqlite3ConnectionFactory* -
-  needs `PySQLite <http://pypi.python.org/pypi/pysqlite/>`_ for connecting to SQLite 3, note that PySQLite is part
+  needs `PySQLite <https://pypi.python.org/pypi/pysqlite/>`_ for connecting to SQLite 3, note that PySQLite is part
   of Python 2.5 and later so you need to install it separately only if you're
   using Python 2.4,
 
 * *springpython.database.factory.cxoraConnectionFactory* -
-  needs `cx_Oracle <http://pypi.python.org/pypi/cx_Oracle>`_ for connecting to Oracle,
+  needs `cx_Oracle <https://pypi.python.org/pypi/cx_Oracle>`_ for connecting to Oracle,
 
 * *springpython.database.factory.SQLServerConnectionFactory* -
-  needs `PyODBC <http://pypi.python.org/pypi/pyodbc>`_ for connecting to SQL Server.
+  needs `PyODBC <https://pypi.python.org/pypi/pyodbc>`_ for connecting to SQL Server.
 
 Traditional Database Query
 ++++++++++++++++++++++++++
 
 If you have written a database SELECT statement following Python's
-`DB-API 2.0 <http://www.python.org/dev/peps/pep-0249/>`_, it would something
+`DB-API 2.0 <https://www.python.org/dev/peps/pep-0249/>`_, it would something
 like this (MySQL example)::
 
     conn = MySQL.connection(username="me", password="secret", hostname="localhost", db="springpython")
@@ -168,7 +168,7 @@ What is a Connection Factory?
 +++++++++++++++++++++++++++++
 
 You may have noticed I didn't make a standard connection in the example above.
-That is because to support `Dependency Injection <http://en.wikipedia.org/wiki/Dependency_injection>`_,
+That is because to support `Dependency Injection <https://en.wikipedia.org/wiki/Dependency_injection>`_,
 I need to setup my credentials in an object before making the actual connection.
 *MySQLConnectionFactory* holds credentials specific to the MySQL DB-API, but
 contains a common function to actually create the connection. I don't have
@@ -196,7 +196,7 @@ You may have noticed in the first three example queries I wrote with the
 *binding variables*, and they require a tuple argument be included after the SQL
 statement. Do *NOT* include quotes around these variables. The database connection
 will handle that. This style of SQL programming is *highly recommended* to avoid
-`SQL injection attacks <http://en.wikipedia.org/wiki/SQL_injection>`_.
+`SQL injection attacks <https://en.wikipedia.org/wiki/SQL_injection>`_.
 
 For users who are familiar with Java database APIs, the binding variables are
 cited using "?" instead of "%s". To make both parties happy and help pave the
@@ -207,8 +207,8 @@ as you wish, and things will still work.
 Have you used Spring Framework's JdbcTemplate?
 ++++++++++++++++++++++++++++++++++++++++++++++
 
-If you are a user of Java's `Spring framework <http://www.springsource.org/>`_
-and have used the `JdbcTemplate <http://static.springsource.org/spring/docs/1.2.x/api/org/springframework/jdbc/core/JdbcTemplate.html>`_,
+If you are a user of Java's `Spring framework <https://www.springsource.org/>`_
+and have used the `JdbcTemplate <https://docs.spring.io/spring/docs/1.2.x/api/org/springframework/jdbc/core/JdbcTemplate.html>`_,
 then you will find this template has a familiar feel.
 
 =================================================================  ================================================================================================

--- a/docs/sphinx/source/jms.rst
+++ b/docs/sphinx/source/jms.rst
@@ -57,8 +57,8 @@ from IBM's site.
 
 :ref:`springpython.jms.listener.SimpleMessageListenerContainer <jms-simplemessagelistenercontainer>`, a Spring Python component which helps with
 running background JMS listeners, requires the installation of
-`Circuits 1.2+ <http://pypi.python.org/pypi/circuits>`_
-and `threadpool 1.2.7 or newer <http://pypi.python.org/pypi/threadpool>`_.
+`Circuits 1.2+ <https://pypi.python.org/pypi/circuits>`_
+and `threadpool 1.2.7 or newer <https://pypi.python.org/pypi/threadpool>`_.
 
 Quick start
 -----------
@@ -1176,7 +1176,7 @@ TextMessage's attributes along with their explanation and usage notes.
 | **jms_correlation_id**       | Equivalent to Java's JMSCorrelationID message header. It must be     |
 |                              | a string instance when set manually - a good way to produce          |
 |                              | correlation identifiers is to use the Python's                       |
-|                              | `uuid4 <http://docs.python.org/library/uuid.html>`_ type, e.g.::     |
+|                              | `uuid4 <https://docs.python.org/library/uuid.html>`_ type, e.g.::     |
 |                              |                                                                      |
 |                              |      # stdlib                                                        |
 |                              |      from uuid import uuid4                                          |
@@ -1393,7 +1393,7 @@ you should always check for their existence before making any use of them.
 Logging and troubleshooting
 ---------------------------
 
-Spring Python's JMS uses standard Python's `logging <http://docs.python.org/library/logging.html>`_
+Spring Python's JMS uses standard Python's `logging <https://docs.python.org/library/logging.html>`_
 module for emitting the messages.
 In general, you can expect JMS to behave sane, it won't overflow your logs with
 meaningless entries, e.g. if you configure it to log the messages at the *ERROR*

--- a/docs/sphinx/source/objects-other-formats.rst
+++ b/docs/sphinx/source/objects-other-formats.rst
@@ -93,7 +93,7 @@ Python platform.
     <beans xmlns="http://www.springframework.org/schema/beans"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.springframework.org/schema/beans
-               http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+               https://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
         <bean id="MovieLister" class="springpythontest.support.testSupportClasses.MovieLister" scope="prototype">
             <property name="finder" ref="MovieFinder"/>
@@ -139,7 +139,7 @@ the *ApplicationContext*.
     feature set.
 
     How much of Spring Java will be supported? That is an open question, best
-    discussed on `Spring Python's community forum <http://forum.springsource.org/forumdisplay.php?f=45>`_.
+    discussed on `Spring Python's community forum <https://forum.spring.io/forumdisplay.php?f=45>`_.
     Basically, this is meant to ease current Java developers into Spring Python and/or
     provide a means to split up objects to support porting parts of your application
     into Python. There isn't any current intention of providing full blown support.

--- a/docs/sphinx/source/objects-xmlconfig.rst
+++ b/docs/sphinx/source/objects-xmlconfig.rst
@@ -198,8 +198,8 @@ as well. The following configuration shows usage of *dict*, *list*, *props*, *se
 * some_dict is a Python dictionary with four entries.
 * some_list is a Python list with three entries.
 * some_props is also a Python dictionary, containing three values.
-* some_set is an instance of Python's `mutable set <http://docs.python.org/library/collections.html?highlight=mutableset#abcs-abstract-base-classes>`_.
-* some_frozen_set is an instance of Python's `frozen set <http://docs.python.org/library/stdtypes.html?#frozenset>`_.
+* some_set is an instance of Python's `mutable set <https://docs.python.org/library/collections.html?highlight=mutableset#abcs-abstract-base-classes>`_.
+* some_frozen_set is an instance of Python's `frozen set <https://docs.python.org/library/stdtypes.html?#frozenset>`_.
 * some_tuple is a Python tuple with three values.
 
 .. note::
@@ -293,7 +293,7 @@ the old :ref:`PyContainer <objects-other-formats-pycontainerconfig>` format woul
 While this is very succinct for expressing definitions using as much Python
 as possible, that format makes it very hard to embed referenced objects and
 inner objects, since PyContainerConfig uses Python's
-`eval <http://docs.python.org/library/functions.html#eval>`_ method to convert
+`eval <https://docs.python.org/library/functions.html#eval>`_ method to convert
 the material.
 
 The following configuration block shows how to configure the same thing for

--- a/docs/sphinx/source/objects-yamlconfig.rst
+++ b/docs/sphinx/source/objects-yamlconfig.rst
@@ -4,7 +4,7 @@ YamlConfig - Spring Python's YAML format
 .. highlight:: yaml
 
 *YamlConfig* is a class that scans object definitions stored in a
-`YAML 1.1 <http://www.yaml.org/>`_ format using the `PyYAML <http://pyyaml.org/>`_
+`YAML 1.1 <https://yaml.org>`_ format using the `PyYAML <https://pyyaml.org/>`_
 project.
 
 The following is a simple definition of objects, including scope and lazy-init.
@@ -187,8 +187,8 @@ and *tuple*::
 * some_dict is a Python dictionary with four entries.
 * some_list is a Python list with three entries.
 * some_props is also a Python dictionary, containing three values.
-* some_set is an instance of Python's `mutable set <http://docs.python.org/library/collections.html?highlight=mutableset#abcs-abstract-base-classes>`_.
-* some_frozen_set is an instance of Python's `frozen set <http://docs.python.org/library/stdtypes.html?#frozenset>`_.
+* some_set is an instance of Python's `mutable set <https://docs.python.org/library/collections.html?highlight=mutableset#abcs-abstract-base-classes>`_.
+* some_frozen_set is an instance of Python's `frozen set <https://docs.python.org/library/stdtypes.html?#frozenset>`_.
 * some_tuple is a Python tuple with three values.
 
 .. note::

--- a/docs/sphinx/source/objects.rst
+++ b/docs/sphinx/source/objects.rst
@@ -2,7 +2,7 @@ The IoC container
 =================
 
 Inversion Of Control (IoC), also known as
-`dependency injection <http://en.wikipedia.org/wiki/Dependency_injection>`_
+`dependency injection <https://en.wikipedia.org/wiki/Dependency_injection>`_
 is more of an architectural concept than a simple coding pattern.
 
 The idea is to decouple classes that depend on each other from inheriting other
@@ -31,7 +31,7 @@ used by a container.
     (DI) principle.
 
     If you need a decent insight into IoC and DI, please do refer to said
-    article : http://martinfowler.com/articles/injection.html.
+    article : https://martinfowler.com/articles/injection.html.
 
 The following diagram demonstrates a key Spring concept: building useful
 services on top of simple objects, configured through a container's set
@@ -45,7 +45,7 @@ External dependencies
 XML-based IoC configuration formats use ElementTree which is a part of Python's
 stantard library in Python 2.5 and newer. If you use Python 2.4 you can
 download ElementTree from here. YamlConfig requires installation of PyYAML
-which may be found `here <http://pypi.python.org/pypi/elementtree>`_.
+which may be found `here <https://pypi.python.org/pypi/elementtree>`_.
 No additional dependencies needs be installed if you choose PythonConfig.
 
 Container
@@ -70,7 +70,7 @@ can be defined by extending the *ObjectContainer* class.
 The reason it is called a container is the idea that you are going to a
 central place to get your top level object. While it is also possible to
 get all your other objects, the core concept of
-`dependency injection <http://en.wikipedia.org/wiki/Dependency_injection>`_ is
+`dependency injection <https://en.wikipedia.org/wiki/Dependency_injection>`_ is
 that below your top-most object, all the other dependencies have been injected
 and thus not require container access. That is what we mean when we say most
 of your code does NOT have to be Spring Python-aware.
@@ -154,8 +154,8 @@ Configuration
 
 Spring Python supports different formats for defining objects.
 
-In the spirit of `Spring JavaConfig <http://www.springsource.org/javaconfig>`_
-and `a blog posting <http://blog.springsource.com/2006/11/28/a-java-configuration-option-for-spring/>`_
+In the spirit of `Spring JavaConfig <https://www.springsource.org/javaconfig>`_
+and `a blog posting <https://spring.io/blog/2006/11/28/a-java-configuration-option-for-spring/>`_
 by Rod Johnson, the :doc:`PythonConfig <objects-pythonconfig>` format has been defined. By extending
 :doc:`PythonConfig <objects-pythonconfig>` and using
 the @Object Python decorator, objects may be defined with pure Python code in a centralized class.

--- a/docs/sphinx/source/overview.rst
+++ b/docs/sphinx/source/overview.rst
@@ -84,7 +84,7 @@ So far, the demos have been based on CherryPy, but the idea is that these
 features should work with any python web framework. The Spring Python team is
 striving to make things reusable with any python-based web framework. There
 is always the goal of expanding the samples into other frameworks, whether
-they are web-based, `RIA <http://en.wikipedia.org/wiki/Rich_Internet_application>`_, or thick-client.
+they are web-based, `RIA <https://en.wikipedia.org/wiki/Rich_Internet_application>`_, or thick-client.
 
 
 Support
@@ -105,32 +105,32 @@ started, so it contains up-to-date information on the project.
 Forums and Email
 ----------------
 
-* You can read the messages on `Spring Python's forums <http://forum.springsource.org/forumdisplay.php?f=45>`_
+* You can read the messages on `Spring Python's forums <https://forum.spring.io/forumdisplay.php?f=45>`_
   at the official Spring forum site.
 
 * If you are interested, you can sign up for the
-  `springpython-developer mailing list <http://lists.springsource.com/listmanager/listinfo/springpython-users>`_.
+  `springpython-developer mailing list <https://lists.springsource.com/listmanager/listinfo/springpython-users>`_.
 
 * You can read the
-  `current archives of the spring-users mailing list <http://lists.springsource.com/archives/springpython-users/>`_.
+  `current archives of the spring-users mailing list <https://lists.springsource.com/archives/springpython-users/>`_.
 
 * You can also read the
-  `old archives of the retired spring-developer mailing list <http://sourceforge.net/mailarchive/forum.php?forum=springpython-developer>`_.
+  `old archives of the retired spring-developer mailing list <https://sourceforge.net/p/legacy_/mailarchive/forum.php?forum=springpython-developer>`_.
 
 * If you want to join this project, see :ref:`how to become a team member <how-to-become-a-team-member>`
 
 IRC
 ---
 
-Join us on the #springpython IRC channel at `Freenode <http://freenode.net>`_.
+Join us on the #springpython IRC channel at `Freenode <https://freenode.net>`_.
 
 Downloads / Source Code
 +++++++++++++++++++++++
 
 If you want a release, check out
-`Spring's download site for Spring Python <http://www.springsource.com/download/community?project=Spring%20Python>`_.
+`Spring's download site for Spring Python <https://www.springsource.com/download/community?project=Spring%20Python>`_.
 
-Spring Python has migrated to `git <http://book.git-scm.com/index.html>`_, the distributed version control system.
+Spring Python has migrated to `git <https://book.git-scm.com/index.html>`_, the distributed version control system.
 If you want the latest source code type::
 
   git clone git://git.springsource.org/spring-python/spring-python.git
@@ -148,7 +148,7 @@ Installation
 
 This section is focused on helping you set up Spring Python.
 
-#. Go to `Spring's download site for Spring Python <http://www.springsource.com/download/community?project=Spring%20Python>`_.
+#. Go to `Spring's download site for Spring Python <https://www.springsource.com/download/community?project=Spring%20Python>`_.
 #. Click on **Spring Python**.
 #. Download **springpython-[release].tar.gz** to get the core library.
 #. Unpack the tarball, and go to the directory containing setup.py. (NOTE: This has been tested on Mac OSX 10.5/10.6, and Ubuntu Linux 9.04+)
@@ -220,7 +220,7 @@ Before sending us a patch, we ask you to sign the
 After a few patches, if things are looking good, we may evaluate giving you
 committer rights.
 
-Spring Python is a `TDD-based <http://en.wikipedia.org/wiki/Test-driven_development>`_
+Spring Python is a `TDD-based <https://en.wikipedia.org/wiki/Test-driven_development>`_
 project, meaning if you are working on code,
 be sure to write an automated test case and write the test case FIRST. For
 insight into that, take a trip into the code repository's test section to
@@ -236,19 +236,19 @@ hold everyone to the same standard.
 .. rubric:: Getting started with contributing
 
 #. First of all, I suggest you sign up on our
-   `springpython-developer <http://lists.springsource.com/listmanager/listinfo/springpython-users>`_
+   `springpython-developer <https://lists.springsource.com/listmanager/listinfo/springpython-users>`_
    mailing list. That way, you'll get notified about big items as well be on the inside
    for important developments that may or may not get published to the web site.
    *NOTE: Use the springsource list, NOT the sourceforge one.*
 
-#. Second, I suggest you register for a `jira account <http://jira.springsource.org/>`_,
+#. Second, I suggest you register for a `jira account <https://jira.springsource.org/>`_,
    so you can leave comments, etc. on the ticket. I think that works (I don't manage
    jira, so if it doesn't let me know, and we will work from there) NOTE: I like
    notes and comments tracking what you have done, or what you think needs to be done.
    It gives us input in case someone else eventually has to complete the ticket.
    That would also be the place where you can append new files or patches to existing code.
 
-#. Third, register at the `SpringSource community forum <http://forum.springsource.org/>`_,
+#. Third, register at the `SpringSource community forum <https://forum.spring.io/>`_,
    and if you want to kick ideas around or float a concept, feel free to start a thread in our Spring
    Python forum.
 

--- a/docs/sphinx/source/plugins.rst
+++ b/docs/sphinx/source/plugins.rst
@@ -3,7 +3,7 @@ Spring Python's plugin system
 
 Spring Python's plugin system is designed to help you rapidly develop applications.
 Plugin-based solutions have been proven to enhance developer efficiency, with
-examples such as `Grails <http://grails.org/>`_ and `Eclipse <http://eclipse.org/>`_
+examples such as `Grails <https://grails.org/>`_ and `Eclipse <https://eclipse.org/>`_
 being market leaders in usage and productivity.
 
 This plugin solution was mainly inspired by the Grails demo presented by
@@ -29,7 +29,7 @@ for you to develop your own plugins as well.
 
     Have you considered submitting your plugin as a Spring Extension?
 
-    `Spring Extensions <http://www.springsource.org/extensions>`_ is the official
+    `Spring Extensions <https://www.springsource.org/extensions>`_ is the official
     incubator process for SpringSource. You can
     always maintain your own plugin separately, using whatever means you wish. But
     if want to get a larger adoption of your plugin, name association with
@@ -62,7 +62,7 @@ The results should list available commands::
 
     Coily - the command-line management tool for Spring Python
     ==========================================================
-    Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+    Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
     Licensed under the Apache License, Version 2.0
 
 
@@ -104,7 +104,7 @@ the *gen-cherrypy-app* plugin, you will see it listed::
 
     Coily - the command-line management tool for Spring Python
     ==========================================================
-    Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+    Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
     Licensed under the Apache License, Version 2.0
 
 
@@ -131,12 +131,12 @@ This section documents plugins that are developed by the Spring Python team.
 External dependencies
 +++++++++++++++++++++
 
-*gen-cherrypy-app* plugin requires the installation of `CherryPy 3 <http://cherrypy.org/>`_.
+*gen-cherrypy-app* plugin requires the installation of `CherryPy 3 <https://cherrypy.org/>`_.
 
 gen-cherrypy-app
 ++++++++++++++++
 
-This plugin is used to generate a skeleton `CherryPy <http://cherrypy.org/>`_
+This plugin is used to generate a skeleton `CherryPy <https://cherrypy.org/>`_
 application based on feeding it a command-line argument::
 
     % coily --gen-cherrypy-app twitterclone
@@ -198,7 +198,7 @@ The special things needed to define a plugin are as follows:
 Case Study - gen-cherrypy-app plugin
 ++++++++++++++++++++++++++++++++++++
 
-*gen-cherrypy-app* is a plugin used to build a `CherryPy <http://cherrypy.org/>`_ web application using
+*gen-cherrypy-app* is a plugin used to build a `CherryPy <https://cherrypy.org/>`_ web application using
 Spring Python's feature set. It saves the developer from having to re-configure
 Spring Python's security module, coding CherryPy's engine, and so forth. This
 allows the developer to immediately start writing business code against a
@@ -213,7 +213,7 @@ Source Code
 ::
 
     """
-       Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+       Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/docs/sphinx/source/remoting.rst
+++ b/docs/sphinx/source/remoting.rst
@@ -31,7 +31,7 @@ Spring Python currently supports and requires the installation of at least one o
 
 * `Pyro <http://pyro.sourceforge.net/>`_ (Python Remote Objects) - a pure Python transport mechanism
 
-* `Pyro4 <http://www.razorvine.net/python/Pyro/>` - (Python Remote Object v.4) - an updated version of the Pyro API.
+* `Pyro4 <https://www.razorvine.net/python/Pyro/>` - (Python Remote Object v.4) - an updated version of the Pyro API.
 
 * `Hessian <http://hessian.caucho.com/>`_ - support for Hessian has just started. So far, you can call
   Python-to-Java based on libraries released from Caucho.
@@ -711,13 +711,13 @@ SSLServer
 >>>>>>>>>
 
 SSLServer is a subclass of Python's
-`SimpleXMLRPCServer.SimpleXMLRPCServer <http://docs.python.org/library/simplexmlrpcserver.html#module-SimpleXMLRPCServer>`_
+`SimpleXMLRPCServer.SimpleXMLRPCServer <https://docs.python.org/library/simplexmlrpcserver.html#module-SimpleXMLRPCServer>`_
 which accepts arguments related to SSL in addition to those inherited from
 the base class. You expose XML-RPC services by extending SSLServer in your
 own subclass which is required to override one method, *register_functions*.
 *register_functions* may in turn use *self.register_function* for exposing those
 methods that should be accessible via XML-RPC, see
-`Python's documentation <http://docs.python.org/library/simplexmlrpcserver.html#SimpleXMLRPCServer.SimpleXMLRPCServer.register_function>`_
+`Python's documentation <https://docs.python.org/library/simplexmlrpcserver.html#SimpleXMLRPCServer.SimpleXMLRPCServer.register_function>`_
 for details of using *self.register_function*.
 
 SSLServer.__init__'s default arguments::
@@ -736,15 +736,15 @@ SSLServer.__init__'s default arguments::
   of Certificate Authorities signing the certificates of clients you deal with,
   e.g. "./ca-chain.pem",
 * *cert_reqs* - whether the client is required to authenticate itself with a certificate,
-  see `Python's documentation <http://docs.python.org/library/ssl.html#ssl.wrap_socket>`_
+  see `Python's documentation <https://docs.python.org/library/ssl.html#ssl.wrap_socket>`_
   for supported values,
 * *ssl_version* - the SSL/TLS version to use, see
-  `Python's documentation <http://docs.python.org/library/ssl.html#ssl.wrap_socket>`_
+  `Python's documentation <https://docs.python.org/library/ssl.html#ssl.wrap_socket>`_
   for supported values, note that the same value **must** be used by the client
   application,
-* *do_handshake_on_connect* - `same as in Python <http://docs.python.org/library/ssl.html#ssl.wrap_socket>`_,
-* *suppress_ragged_eofs* - `same as in Python <http://docs.python.org/library/ssl.html#ssl.wrap_socket>`_,
-* *ciphers* - `same as in Python <http://docs.python.org/library/ssl.html#ssl.wrap_socket>`_,
+* *do_handshake_on_connect* - `same as in Python <https://docs.python.org/library/ssl.html#ssl.wrap_socket>`_,
+* *suppress_ragged_eofs* - `same as in Python <https://docs.python.org/library/ssl.html#ssl.wrap_socket>`_,
+* *ciphers* - `same as in Python <https://docs.python.org/library/ssl.html#ssl.wrap_socket>`_,
   the value will be silently ignored if not running Python 2.7 or newer,
 * *log_requests* - whether requests should be logged on stdout, the value is actually
   passed directly to the request handler and that's why in current version
@@ -754,7 +754,7 @@ SSLServer.__init__'s default arguments::
 * *\**kwargs* - an open-ended list of keyword arguments, currently the only
   argument being recognized is *verify_fields* which must be a dictionary
   containing fields and values of the client certificate that must exist when the client's
-  connecting. Fields names should be in the format given in `Appendix A of RFC 3280 <http://tools.ietf.org/html/rfc3280>`_,
+  connecting. Fields names should be in the format given in `Appendix A of RFC 3280 <https://tools.ietf.org/html/rfc3280>`_,
   which means using long names instead of short ones (commonName not CN, organizationName not O, etc.),
   for instance, setting verify_fields to:
 
@@ -811,7 +811,7 @@ SSLClient
 >>>>>>>>>
 
 SSLClient extends Python's built-in
-`xmlrpclib.ServerProxy <http://docs.python.org/library/xmlrpclib.html#xmlrpclib.ServerProxy>`_
+`xmlrpclib.ServerProxy <https://docs.python.org/library/xmlrpclib.html#xmlrpclib.ServerProxy>`_
 class and, unlike :ref:`SSLServer <remoting-secure-xml-config-sslserver>`,
 can be used directly without the need for subclassing. You can simply create
 an instance and start invoking server's methods.
@@ -832,18 +832,18 @@ SSLClient.__init__’s default arguments::
 * *keyfile* - path to a PAM-encoded private key of the client, e.g. "./client-key.pem",
 * *certfile* - path to a PAM-encoded certificate of the client, e.g. "./client-key.pem",
 * *cert_reqs* - whether a server is required to have a certificate,
-  see `Python's documentation <http://docs.python.org/library/ssl.html#ssl.wrap_socket>`_
+  see `Python's documentation <https://docs.python.org/library/ssl.html#ssl.wrap_socket>`_
   for supported values,
 * *ssl_version* - the SSL/TLS version to use, see
-  `Python's documentation <http://docs.python.org/library/ssl.html#ssl.wrap_socket>`_
+  `Python's documentation <https://docs.python.org/library/ssl.html#ssl.wrap_socket>`_
   for supported values, note that the same value **must** be used by the server,
-* *transport* - `same as in Python <http://docs.python.org/library/xmlrpclib.html#xmlrpclib.ServerProxy>`_,
-* *encoding* - `same as in Python <http://docs.python.org/library/xmlrpclib.html#xmlrpclib.ServerProxy>`_,
-* *verbose* - `same as in Python <http://docs.python.org/library/xmlrpclib.html#xmlrpclib.ServerProxy>`_,
-* *allow_none* - `same as in Python <http://docs.python.org/library/xmlrpclib.html#xmlrpclib.ServerProxy>`_,
-* *use_datetime* - `same as in Python <http://docs.python.org/library/xmlrpclib.html#xmlrpclib.ServerProxy>`_,
-* *timeout* - `same as in Python <http://docs.python.org/library/httplib.html#httplib.HTTPConnection>`_,
-* *strict* - `same as in Python <http://docs.python.org/library/httplib.html#httplib.HTTPConnection>`_
+* *transport* - `same as in Python <https://docs.python.org/library/xmlrpclib.html#xmlrpclib.ServerProxy>`_,
+* *encoding* - `same as in Python <https://docs.python.org/library/xmlrpclib.html#xmlrpclib.ServerProxy>`_,
+* *verbose* - `same as in Python <https://docs.python.org/library/xmlrpclib.html#xmlrpclib.ServerProxy>`_,
+* *allow_none* - `same as in Python <https://docs.python.org/library/xmlrpclib.html#xmlrpclib.ServerProxy>`_,
+* *use_datetime* - `same as in Python <https://docs.python.org/library/xmlrpclib.html#xmlrpclib.ServerProxy>`_,
+* *timeout* - `same as in Python <https://docs.python.org/library/httplib.html#httplib.HTTPConnection>`_,
+* *strict* - `same as in Python <https://docs.python.org/library/httplib.html#httplib.HTTPConnection>`_
 
 Sample SSL XML-RPC client which uses a private key and a certificate, can be
 used for invoking the :ref:`server <remoting-secure-xml-config-sslserver-sample>`
@@ -874,7 +874,7 @@ SSLServer
 >>>>>>>>>
 
 Your subclass of SSLServer can be configured to use Python's
-standard `logging <http://docs.python.org/library/logging.html>`_ module.
+standard `logging <https://docs.python.org/library/logging.html>`_ module.
 Currently, logging events are emitted at *logging.DEBUG* and *logging.ERROR* levels.
 
 At ERROR level all failed attempts at validating of client certificates will
@@ -943,7 +943,7 @@ SSLClient
 Although SSLClient does define a self.logger object it isn't currently used
 internally in any situation (subject to change without notice so you shouldn't
 rely on the current status). On the other hand, as a subclass of
-`xmlrpclib.ServerProxy <http://docs.python.org/library/xmlrpclib.html#xmlrpclib.ServerProxy>`_,
+`xmlrpclib.ServerProxy <https://docs.python.org/library/xmlrpclib.html#xmlrpclib.ServerProxy>`_,
 the client may be configured to run in a *verbose* mode which means all HTTP traffic
 will be printed onto *standard output*.
 

--- a/docs/sphinx/source/samples.rst
+++ b/docs/sphinx/source/samples.rst
@@ -6,7 +6,7 @@ PetClinic
 
 PetClinic is a sample application demonstrating the usage of Spring Python.
 
-* It uses `CherryPy <http://cherrypy.org/>`_ as the web server object.
+* It uses `CherryPy <https://cherrypy.org/>`_ as the web server object.
 
 * A `detailed design document <https://fisheye.springsource.org/browse/se-springpython-py/samples/petclinic/cherrypy/html/petclinic.html>`_
   (NOTE: find latest version, and click on raw) is
@@ -32,7 +32,7 @@ After that, it will have setup database *petclinic*::
   bash$ cd cherrypy
   bash$ python petclinic.py
 
-This assumes you have `CherryPy 3 <http://cherrypy.org/>`_  installed. It probably
+This assumes you have `CherryPy 3 <https://cherrypy.org/>`_  installed. It probably
 *won't* work if you are still using CherryPy 2. NOTE: If you are using Python 2.5.2+, you must install
 CherryPy 3.1.2+. The older version of CherryPy (3.1.0) only works pre-2.5.2.
 
@@ -61,7 +61,7 @@ Why write a bot?
 ++++++++++++++++
 
 I read an article,
-`Building a community around your open source project <http://www.redhatmagazine.com/2007/09/21/building-a-community-around-your-open-source-project/>`_,
+`Building a community around your open source project <https://magazine.redhat.com/2007/09/21/building-a-community-around-your-open-source-project/>`_,
 that talked about setting up an IRC channel for your project. This is a route
 to support existing users, and allow them to work with each other.
 
@@ -80,7 +80,7 @@ For Ubuntu users::
 
   % sudo apt-get install python-irclib
 
-This bot also sports a web page using `CherryPy <http://cherrypy.org/>`_.
+This bot also sports a web page using `CherryPy <https://cherrypy.org/>`_.
 You also need to install that as well.
 
 Articles
@@ -102,11 +102,11 @@ What I built
 Using this, I managed to get something primitive running. It took me a while
 to catch on that posting private messages on a channel name instead of a user
 is the way to publicly post to a channel. I guess it helped to trip through
-the `IRC RFC <http://www.irchelp.org/irchelp/rfc/rfc.html>`_ manual, before catching on to this.
+the `IRC RFC <https://www.irchelp.org/irchelp/rfc/rfc.html>`_ manual, before catching on to this.
 
-At this stage, you may wish to get familiar with `regular expressions in Python <http://www.amk.ca/python/howto/regex/>`_.
+At this stage, you may wish to get familiar with `regular expressions in Python <https://www.amk.ca/python/howto/regex/>`_.
 You will certainly need this in order to make intelligent looking patterns.
-Anything more sophisticated would probably require `PLY <http://www.dabeaz.com/ply/>`_.
+Anything more sophisticated would probably require `PLY <https://www.dabeaz.com/ply/>`_.
 
 What I really like is that fact that I built this application in approximately
 24 hours, counting the time to learn how to use python-irclib. I already knew
@@ -116,7 +116,7 @@ article should demonstrate how long it took.
 NOTE: This whole script is contained in one file, and marked up as::
 
   """
-     Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+     Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -268,14 +268,14 @@ Spring-based web app::
             <hr>
             <table style="width:100%"><tr>
                     <td><A href="/">Home</A></td>
-                    <td style="text-align:right;color:silver">Coily :: a <a href="http://springpython.webfactional.com">Spring Python</a> IRC bot (powered by <A HREF="http://www.cherrypy.org">CherryPy</A>)</td>
+                    <td style="text-align:right;color:silver">Coily :: a <a href="http://springpython.webfactional.com">Spring Python</a> IRC bot (powered by <A HREF="https://www.cherrypy.org">CherryPy</A>)</td>
             </tr></table>
 
             </body>
             """
 
     def markup(text):
-        """Convert any http://xyz references into real web links."""
+        """Convert any https://xyz references into real web links."""
         httpR = re.compile(r"(http://[\w.:/?-]*\w)")
         alteredText = httpR.sub(r'<A HREF="\1">\1</A>', text)
         return alteredText
@@ -515,4 +515,4 @@ Unfortunately, at this time, I don't have a mechanism to make it run persistentl
 External Links
 ++++++++++++++
 
-`See this article reported in LinuxToday <http://www.linuxtoday.com/news_story.php3?ltsn=2007-10-12-009-26-OS-DV-NT>`_
+`See this article reported in LinuxToday <https://www.linuxtoday.com/news_story.php3?ltsn=2007-10-12-009-26-OS-DV-NT>`_

--- a/docs/sphinx/source/security.rst
+++ b/docs/sphinx/source/security.rst
@@ -17,7 +17,7 @@ for a background on this module.
 External dependencies
 ---------------------
 
-*springpython.security.cherrypy3* package depends on `CherryPy 3 <http://cherrypy.org/>`_
+*springpython.security.cherrypy3* package depends on `CherryPy 3 <https://cherrypy.org/>`_
 being installed prior to using it. Other than that, there are no specific external libraries
 required by Spring Python's security system, however the IoC configuration
 format that you'll be using may need some, check IoC documentation

--- a/generate_site.bash
+++ b/generate_site.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 ###################################################################################
-#   Copyright 2006-2011 SpringSource (http://springsource.com), All Rights Reserved
+#   Copyright 2006-2011 SpringSource (https://springsource.com), All Rights Reserved
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/samples/petclinic/cherrypy/controller.py
+++ b/samples/petclinic/cherrypy/controller.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/samples/petclinic/cherrypy/html/petclinic.html
+++ b/samples/petclinic/cherrypy/html/petclinic.html
@@ -17,7 +17,7 @@
 &nbsp;&nbsp;&nbsp; 16-AUG-2003 - Ken Krebs</FONT></P>
 <H2>Introduction</H2>
 <P><A HREF="https://springpython.webfactional.com">Spring Python</A> is a collection of small, well-focused, loosely
-coupled <A HREF="http://www.python.org/">Python</A> frameworks that
+coupled <A HREF="https://www.python.org/">Python</A> frameworks that
 can be used independently or collectively to build industrial
 strength applications of many different types. The PetClinic sample
 application is designed to show how the Spring Python application
@@ -42,12 +42,12 @@ This infrastructure helps developers to create applications that are
 <UL>
 	<LI><P STYLE="margin-bottom: 0in"><B><U>concise</U></B> by handling
 	a lot of the complex control flow that is needed to use certain
-	Python API's, such as <A HREF="http://www.python.org/dev/peps/pep-0249">DB-2
+	Python API's, such as <A HREF="https://www.python.org/dev/peps/pep-0249">DB-2
 	API</A>, remoting through <A HREF="http://pyro.sourceforge.net/">PYRO</A>
 		</P>
 	<LI><P STYLE="margin-bottom: 0in"><B><U>flexible</U></B> by
 	simplifying the process of external application configuration
-	through the use of <A HREF="http://diveintopython.org/power_of_introspection/index.html">Introspection</A>
+	through the use of <A HREF="/UcONZ/power_of_introspection/index.html">Introspection</A>
 	and object creation. This allows the developer to achieve a clean
 	separation of configuration data from application code. All
 	application objects, including database connection factories,
@@ -61,7 +61,7 @@ This infrastructure helps developers to create applications that are
 	presentation framework that can work seamlessly with many different
 	types of view technologies. The Petclinic web application
 	demonstrates &quot;plugging in&quot; to one popular Python web
-	framework, <A HREF="http://www.cherrypy.org/">CherryPy</A>, while
+	framework, <A HREF="https://www.cherrypy.org/">CherryPy</A>, while
 	keeping the database layer and the model definitions neatly
 	separated. This helps developers to implement their Presentation as
 	a clean and thin layer focused on its main missions of translating
@@ -116,11 +116,11 @@ Cases:</B></P>
 </OL>
 <H2>PetClinic Sample Application Design &amp; Implementation</H2>
 <P><B><U>Server Technology</U></B><BR>The sample application is
-written using <A HREF="http://www.cherrypy.org/">CherryPy</A> as the
+written using <A HREF="https://www.cherrypy.org/">CherryPy</A> as the
 web container. CherryPy applications are self-contained web servers
 utilizing Python's built in HTTPServer objects. CherryPy
 applications do not require a 3rd party web server, such as Apache or
-IIS. However, it is possible to <A HREF="http://cherrypy.org/wiki/BehindApache">configure
+IIS. However, it is possible to <A HREF="https://cherrypy.org/wiki/BehindApache">configure
 the CherryPy web application</A> to be fronted by a web server, and
 even spawned.<BR>In order to run the application, you must install
 CherryPy. You can download the package from their web site and
@@ -131,7 +131,7 @@ apt-get install python-cherrypy</FONT></CODE></P>
 uses a relational database for data storage. To reset the database,
 it is probably easiest to just re-run the setup.py script.</P>
 <UL>
-	<LI><P>Support is provided for <A HREF="http://mysql.com/">MySQL</A>.
+	<LI><P>Support is provided for <A HREF="https://mysql.com/">MySQL</A>.
 	Setup requires the user to provide the MySQL &quot;root&quot;
 	password, in order to setup to the &quot;springpython&quot; user and
 	&quot;petclinic&quot; database. You need to have MySQL python module

--- a/samples/petclinic/cherrypy/model.py
+++ b/samples/petclinic/cherrypy/model.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/samples/petclinic/cherrypy/noxml.py
+++ b/samples/petclinic/cherrypy/noxml.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/samples/petclinic/cherrypy/petclinic-client-xml.py
+++ b/samples/petclinic/cherrypy/petclinic-client-xml.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/samples/petclinic/cherrypy/petclinic-client.py
+++ b/samples/petclinic/cherrypy/petclinic-client.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/samples/petclinic/cherrypy/petclinic-server-xml.py
+++ b/samples/petclinic/cherrypy/petclinic-server-xml.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/samples/petclinic/cherrypy/petclinic-server.py
+++ b/samples/petclinic/cherrypy/petclinic-server.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/samples/petclinic/cherrypy/petclinic-xml.py
+++ b/samples/petclinic/cherrypy/petclinic-xml.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/samples/petclinic/cherrypy/petclinic.py
+++ b/samples/petclinic/cherrypy/petclinic.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/samples/petclinic/cherrypy/view.py
+++ b/samples/petclinic/cherrypy/view.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ def footer():
         <hr>
         <table style="width:100%"><tr>
                 <td><A href="/">Home</A></td>
-                <td style="text-align:right;color:silver">PetClinic :: a <a href="http://springpython.webfactional.com">Spring Python</a> demonstration (powered by <A HREF="http://www.cherrypy.org">CherryPy</A>)</td>
+                <td style="text-align:right;color:silver">PetClinic :: a <a href="http://springpython.webfactional.com">Spring Python</a> demonstration (powered by <A HREF="https://www.cherrypy.org">CherryPy</A>)</td>
         </tr></table>
         </body>
         """

--- a/samples/petclinic/configure.py
+++ b/samples/petclinic/configure.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/samples/setup-template.py
+++ b/samples/setup-template.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/samples/springirc/coily
+++ b/samples/springirc/coily
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -59,14 +59,14 @@ def footer():
         <hr>
         <table style="width:100%"><tr>
                 <td><A href="/">Home</A></td>
-                <td style="text-align:right;color:silver">Coily :: a <a href="http://springpython.webfactional.com">Spring Python</a> IRC bot (powered by <A HREF="http://www.cherrypy.org">CherryPy</A>)</td>
+                <td style="text-align:right;color:silver">Coily :: a <a href="http://springpython.webfactional.com">Spring Python</a> IRC bot (powered by <A HREF="https://www.cherrypy.org">CherryPy</A>)</td>
         </tr></table>
         
         </body>
         """
 
 def markup(text):
-    """Convert any http://xyz references into real web links."""
+    """Convert any https://xyz references into real web links."""
     httpR = re.compile(r"(http://[\w.:/?-]*\w)")
     alteredText = httpR.sub(r'<A HREF="\1">\1</A>', text)
     return alteredText

--- a/samples/springirc/springbot.py
+++ b/samples/springirc/springbot.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/samples/springwiki/controller.py
+++ b/samples/springwiki/controller.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ This is a demonstration of [http://springpython.webfactional.com Spring Python].
 What do you think?
 
 ==== Level 4 Header ====
-Personally, I think this is cool. This is a wiki engine that uses the same wiki-text as [http://en.wikipedia.org Wikipedia].
+Personally, I think this is cool. This is a wiki engine that uses the same wiki-text as [https://en.wikipedia.org Wikipedia].
 
 There are many features:
 * You can make intrawiki links
@@ -58,7 +58,7 @@ By using Python, you get:
 * And finally, [[CherryPy]] finishes it up by offering lightning fast web development time.
     """, [("Original", "This is the initial entry", "20:02, 6 October 2006", "User:Gregturn"), ("First edit", "This is an edit", "20:12, 12 October 2006", "User:Gregturn")]],
     "Spring Wiki":["""Spring Wiki is a demonstration application that shows how to write a wiki engine using Spring Python and [[CherryPy]].""", []],
-    "CherryPy":["""[http://www.cherrypy.org CherryPy] is a web application framework.""", []],
+    "CherryPy":["""[https://www.cherrypy.org CherryPy] is a web application framework.""", []],
     "Springwiki Sidebar": ["""
 Single-star entries define boxes in the sidebar. Double-star boxes define the links listed underneath the boxes.
 

--- a/samples/springwiki/css/commonPrint.css
+++ b/samples/springwiki/css/commonPrint.css
@@ -2,11 +2,11 @@
 ** MediaWiki Print style sheet for CSS2-capable browsers.
 ** Copyright Gabriel Wicke, http://www.aulinx.de/
 **
-** Derived from the plone (http://plone.org/) styles
+** Derived from the plone (https://plone.org/) styles
 ** Copyright Alexander Limi
 */
 
-/* Thanks to A List Apart (http://alistapart.com/) for useful extras */
+/* Thanks to A List Apart (https://alistapart.com/) for useful extras */
 a.stub,
 a.new{ color:#ba0000; text-decoration:none; }
 

--- a/samples/springwiki/css/main.css
+++ b/samples/springwiki/css/main.css
@@ -1,10 +1,10 @@
 /*
 ** MediaWiki 'monobook' style sheet for CSS2-capable browsers.
-** Copyright Gabriel Wicke - http://wikidev.net/
-** License: GPL (http://www.gnu.org/copyleft/gpl.html)
+** Copyright Gabriel Wicke - https://sites.google.com/site/wickelandschaft//
+** License: GPL (https://www.gnu.org/copyleft/gpl.html)
 **
 ** Loosely based on http://www.positioniseverything.net/ordered-floats.html by Big John
-** and the Plone 2.0 styles, see http://plone.org/ (Alexander Limi,Joe Geldart & Tom Croucher,
+** and the Plone 2.0 styles, see https://plone.org/ (Alexander Limi,Joe Geldart & Tom Croucher,
 ** Michael Zeltner and Geir Bækholt)
 ** All you guys rock :)
 */
@@ -40,8 +40,8 @@ td { padding:3px; }
 
 /* Font size:
 ** We take advantage of keyword scaling- browsers won't go below 9px
-** More at http://www.w3.org/2003/07/30-font-size
-** http://style.cleverchimp.com/font_size_intervals/altintervals.html
+** More at https://www.w3.org/2003/07/30-font-size
+** https://style.cleverchimp.com/font_size_intervals/altintervals.html
 */
 
 body {

--- a/samples/springwiki/css/sticky.js
+++ b/samples/springwiki/css/sticky.js
@@ -1,6 +1,6 @@
 // Make a layer that stays in the same place on screen when scrolling the browser window.
 // Version 1.2
-// See http://www.mark.ac/help for browser support.
+// See https://www.mark.ac/help for browser support.
 
 var mySticky;
 var theLayer;
@@ -63,7 +63,7 @@ lastY=10;YOffset=0;staticYOffset=10;refreshMS=25;
 
 // -------------------------
 // DHTML menu sliding. Requires checkBrowser()
-// Based on source at http://www.simplythebest.net/
+// Based on source at https://www.simplythebest.net/
 	function layerSlide(layerID) {
 		if(bw.dhtml){
 			if(!mySticky){mySticky=new makeLayerObj(layerID);}

--- a/samples/springwiki/model.py
+++ b/samples/springwiki/model.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -234,7 +234,7 @@ class Page(object):
                         </div><!-- f-poweredbyico -->
                         <ul id="f-list">
                             <li id="f-about">
-                                SpringWiki :: a <a href="http://springpython.webfactional.com">Spring Python</a> demonstration (powered by <A HREF="http://www.cherrypy.org">CherryPy</A>)
+                                SpringWiki :: a <a href="http://springpython.webfactional.com">Spring Python</a> demonstration (powered by <A HREF="https://www.cherrypy.org">CherryPy</A>)
                             </li>
                         </ul>
                     </div><!-- footer -->
@@ -360,7 +360,7 @@ class EditPage(Page):
                 addButton('../images/button_bold.png','Bold text','\'\'\'','\'\'\'','Bold text');
                 addButton('/images/button_italic.png','Italic text','\'\'','\'\'','Italic text');
                 addButton('images/button_link.png','Internal link','[[',']]','Link title');
-                addButton('images/button_extlink.png','External link (remember http:// prefix)','[',']','http://www.example.com link title');
+                addButton('images/button_extlink.png','External link (remember http:// prefix)','[',']','https://www.example.com link title');
                 addButton('images/button_headline.png','Level 2 headline','\n== ',' ==\n','Headline text');
                 addButton('images/button_image.png','Embedded image','[[Image:',']]','Example.jpg');
                 addButton('images/button_media.png','Media file link','[[Media:',']]','Example.ogg');

--- a/samples/springwiki/noxml.py
+++ b/samples/springwiki/noxml.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/samples/springwiki/springwiki-noxml.py
+++ b/samples/springwiki/springwiki-noxml.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/samples/springwiki/springwiki.py
+++ b/samples/springwiki/springwiki.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/samples/springwiki/view.py
+++ b/samples/springwiki/view.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/plugins/coily-template
+++ b/src/plugins/coily-template
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-   Copyright 2006-2009 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2009 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -87,7 +87,7 @@ def get_modules_from_s3():
     """Read the S3 site for information about existing modules."""
     info = ""
     for bucket in ["milestone", "release"]:
-        url = "http://s3browse.springsource.com/browse/dist.springframework.org/%s/EXTPY" % bucket
+        url = "https://s3browse.springsource.com/browse/dist.springframework.org/%s/EXTPY" % bucket
         info += urllib.urlopen(url).read()
     #print info
     #return []
@@ -103,7 +103,7 @@ def get_modules_from_s3():
         converted.append(item)
         #t = time.strptime(item[3], "%Y-%m-%d %H:%M")
         #d = datetime(year=t.tm_year, month=t.tm_mon, day=t.tm_mday, hour=t.tm_hour, minute=t.tm_min)
-        #converted.append(("http://s3.amazonaws.com/" + item[0], item[1], item[2]+"K", item[3], d))
+        #converted.append(("https://s3.amazonaws.com/" + item[0], item[1], item[2]+"K", item[3], d))
     modules = {}
     baseR = re.compile("springpython-plugin-([a-zA-Z-]*)[-.]([0-9a-zA-Z]+.*).tar.gz")
     for item in converted:
@@ -190,7 +190,7 @@ def usage():
 
 print "Coily v%s - the command-line management tool for Spring Python, http://springpython.webfactional.com" % __version__
 print "==============================================================================="
-print "Copyright 2006-2009 SpringSource (http://springsource.com), All Rights Reserved"
+print "Copyright 2006-2009 SpringSource (https://springsource.com), All Rights Reserved"
 print "Licensed under the Apache License, Version 2.0"
 print
 

--- a/src/plugins/gen-cherrypy-app/__init__.py
+++ b/src/plugins/gen-cherrypy-app/__init__.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/plugins/gen-cherrypy-app/app_context.py
+++ b/src/plugins/gen-cherrypy-app/app_context.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/plugins/gen-cherrypy-app/cherrypy-app.py
+++ b/src/plugins/gen-cherrypy-app/cherrypy-app.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/plugins/gen-cherrypy-app/controller.py
+++ b/src/plugins/gen-cherrypy-app/controller.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/plugins/gen-cherrypy-app/view.py
+++ b/src/plugins/gen-cherrypy-app/view.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ def footer():
         <hr>
         <table style="width:100%"><tr>
                 <td><A href="/">Home</A></td>
-                <td style="text-align:right;color:silver">${properName} Application :: A <a href="http://cherrypy.org">CherryPy</a>-based ${properName} application-creating template</td>
+                <td style="text-align:right;color:silver">${properName} Application :: A <a href="https://cherrypy.org">CherryPy</a>-based ${properName} application-creating template</td>
         </tr></table>
         </body>
         """

--- a/src/setup-template.py
+++ b/src/setup-template.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/COPYRIGHT
+++ b/src/springpython/COPYRIGHT
@@ -1,4 +1,4 @@
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
    limitations under the License.       
 *****************************************************************************************
 
-Spring Python is inspired by the Spring framework (http://www.springframework.org)
+Spring Python is inspired by the Spring framework (https://www.springframework.org)
 which is released under the Apache Foundation License. Spring Python does NOT require
 redistribution of Spring's software modules, nor any of its dependencies (binary or source code).
 However, you are free to download their source code to understand the basis of this product.
@@ -54,7 +54,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 DAMAGE.
 
 *****************************************************************************************
-Spring Python includes software developed by Fourthought, Inc. (http://www.fourthought.com).
+Spring Python includes software developed by Fourthought, Inc. (https://www.pinkertonpw.com/).
 
 License and copyright info for 4Suite software License and copyright info for 4Suite
 software Mike Olson Fourthought, Inc. Uche Ogbuji Fourthought, Inc. License and copyright
@@ -77,7 +77,7 @@ reproduce the above copyright notice, this list of conditions and the following 
 in the documentation and/or other materials provided with the distribution. The end-user
 documentation included with the redistribution, if any, must include the following
 acknowledgment: "This product includes software developed by Fourthought, Inc.
-(http://www.fourthought.com)." Alternately, this acknowledgment may appear in the software
+(https://www.pinkertonpw.com/)." Alternately, this acknowledgment may appear in the software
 itself, if and wherever such third-party acknowledgments normally appear. The names "4Suite",
 "4Suite Server" and "Fourthought" must not be used to endorse or promote products derived from
 this software without prior written permission. For written permission, please contact
@@ -98,7 +98,7 @@ This license is based on the Apache Software License, Version 1.1,
 Copyright (c) 2000 The Apache Software Foundation. All rights reserved. 
 
 *****************************************************************************************
-Spring Python includes software developed by Uche Ogbuji (http://uche.ogbuji.net).
+Spring Python includes software developed by Uche Ogbuji (https://uche.ogbuji.net).
 
 Redistribution and use in source and binary forms, with or without modification, are permitted
 provided that the following conditions are met:
@@ -110,7 +110,7 @@ provided that the following conditions are met:
       with the distribution.
    3. The end-user documentation included with the redistribution, if any, must include the
       following acknowledgment: "This product includes software developed by Uche Ogbuji
-      (http://uche.ogbuji.net)." Alternately, this acknowledgment may appear in the software
+      (https://uche.ogbuji.net)." Alternately, this acknowledgment may appear in the software
       itself, if and wherever such third-party acknowledgments normally appear.
    4. The names "Amara" and "Uche Ogbuji" must not be used to endorse or promote products derived
       from this software without prior written permission of Uche Ogbuji (uche@ogbuji.net).

--- a/src/springpython/__init__.py
+++ b/src/springpython/__init__.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/aop/__init__.py
+++ b/src/springpython/aop/__init__.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/aop/utils.py
+++ b/src/springpython/aop/utils.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/config/__init__.py
+++ b/src/springpython/config/__init__.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/config/_config_base.py
+++ b/src/springpython/config/_config_base.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/config/_python_config.py
+++ b/src/springpython/config/_python_config.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/config/_xml_config.py
+++ b/src/springpython/config/_xml_config.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/config/_yaml_config.py
+++ b/src/springpython/config/_yaml_config.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/config/decorator.py
+++ b/src/springpython/config/decorator.py
@@ -24,7 +24,7 @@
 ##   DAMAGE.
 
 """
-Decorator module, see http://pypi.python.org/pypi/decorator
+Decorator module, see https://pypi.python.org/pypi/decorator
 for the documentation.
 """
 

--- a/src/springpython/container/__init__.py
+++ b/src/springpython/container/__init__.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/context/__init__.py
+++ b/src/springpython/context/__init__.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/context/scope.py
+++ b/src/springpython/context/scope.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/database/__init__.py
+++ b/src/springpython/database/__init__.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/database/core.py
+++ b/src/springpython/database/core.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/database/factory.py
+++ b/src/springpython/database/factory.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/database/transaction.py
+++ b/src/springpython/database/transaction.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/factory/__init__.py
+++ b/src/springpython/factory/__init__.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/jms/__init__.py
+++ b/src/springpython/jms/__init__.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/jms/core.py
+++ b/src/springpython/jms/core.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/jms/factory.py
+++ b/src/springpython/jms/factory.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/jms/listener.py
+++ b/src/springpython/jms/listener.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/remoting/__init__.py
+++ b/src/springpython/remoting/__init__.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/remoting/hessian/__init__.py
+++ b/src/springpython/remoting/hessian/__init__.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/remoting/hessian/hessianlib.py
+++ b/src/springpython/remoting/hessian/hessianlib.py
@@ -29,7 +29,7 @@
 # 3. The end-user documentation included with the redistribution, if
 #    any, must include the following acknowlegement:
 #       "This product includes software developed by the
-#        Caucho Technology (http://www.caucho.com/)."
+#        Caucho Technology (https://www.caucho.com/)."
 #    Alternately, this acknowlegement may appear in the software itself,
 #    if and wherever such third-party acknowlegements normally appear.
 #
@@ -399,7 +399,7 @@ class _Method:
 # Hessian is the main class.  A Hessian proxy is created with the URL
 # and then called just as for a local method
 #
-# proxy = Hessian("http://www.caucho.com/hessian/test/basic")
+# proxy = Hessian("http://hessian.caucho.com/test/basic")
 # print proxy.hello()
 #
 class Hessian:

--- a/src/springpython/remoting/http.py
+++ b/src/springpython/remoting/http.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-   Copyright 2006-2011 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2011 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/remoting/pyro/Pyro4DaemonHolder.py
+++ b/src/springpython/remoting/pyro/Pyro4DaemonHolder.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/remoting/pyro/PyroDaemonHolder.py
+++ b/src/springpython/remoting/pyro/PyroDaemonHolder.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/remoting/pyro/__init__.py
+++ b/src/springpython/remoting/pyro/__init__.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/remoting/xmlrpc.py
+++ b/src/springpython/remoting/xmlrpc.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-   Copyright 2006-2011 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2011 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/security/__init__.py
+++ b/src/springpython/security/__init__.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/security/cherrypy3.py
+++ b/src/springpython/security/cherrypy3.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/security/context/SecurityContextHolder.py
+++ b/src/springpython/security/context/SecurityContextHolder.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/security/context/__init__.py
+++ b/src/springpython/security/context/__init__.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/security/intercept.py
+++ b/src/springpython/security/intercept.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/security/providers/Ldap.py
+++ b/src/springpython/security/providers/Ldap.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/security/providers/_Ldap_cpython.py
+++ b/src/springpython/security/providers/_Ldap_cpython.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2009 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2009 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/security/providers/_Ldap_jython.py
+++ b/src/springpython/security/providers/_Ldap_jython.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2009 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2009 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ print """
 WARNING WARNING WARNING WARNING
 ===============================
 This doesn't yet work. There is some issue with Jython.
-See http://bugs.jython.org/issue1489 and http://jira.springframework.org/browse/SESPRINGPYTHONPY-121 for more details.
+See https://bugs.jython.org/issue1489 and https://jira.springframework.org/browse/SESPRINGPYTHONPY-121 for more details.
 ===============================
 WARNING WARNING WARNING WARNING
 """

--- a/src/springpython/security/providers/__init__.py
+++ b/src/springpython/security/providers/__init__.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/security/providers/dao.py
+++ b/src/springpython/security/providers/dao.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/security/providers/encoding.py
+++ b/src/springpython/security/providers/encoding.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/security/userdetails/__init__.py
+++ b/src/springpython/security/userdetails/__init__.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/security/userdetails/dao.py
+++ b/src/springpython/security/userdetails/dao.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/security/vote.py
+++ b/src/springpython/security/vote.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/security/web.py
+++ b/src/springpython/security/web.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/springpython/util.py
+++ b/src/springpython/util.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ TRACE1 = 6
 logging.addLevelName(TRACE1, "TRACE1")
 
 # Original code by Anand Balachandran Pillai (abpillai at gmail.com)
-# http://code.activestate.com/recipes/533135/
+# https://code.activestate.com/recipes/533135/
 class synchronized(object):
     """ Class enapsulating a lock and a function allowing it to be used as
     a synchronizing decorator making the wrapped function thread-safe """

--- a/test.bash
+++ b/test.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 ###################################################################################
-#   Copyright 2006-2011 SpringSource (http://springsource.com), All Rights Reserved
+#   Copyright 2006-2011 SpringSource (https://springsource.com), All Rights Reserved
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/test/springpythontest/__init__.py
+++ b/test/springpythontest/__init__.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/test/springpythontest/allTests.py
+++ b/test/springpythontest/allTests.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/test/springpythontest/aopTestCases.py
+++ b/test/springpythontest/aopTestCases.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/test/springpythontest/contextTestCases.py
+++ b/test/springpythontest/contextTestCases.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/test/springpythontest/databaseCoreTestCases.py
+++ b/test/springpythontest/databaseCoreTestCases.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -883,7 +883,7 @@ class SQLServerDatabaseTemplateTestCase(AbstractDatabaseTemplateTestCase):
             print("""
                 !!! Can't run SQLServerDatabaseTemplateTestCase !!!
 
-                This assumes you have installed pyodbc (http://code.google.com/p/pyodbc/).
+                This assumes you have installed pyodbc (https://code.google.com/p/pyodbc/).
 
                 And then created an SQL Server database for the 'springpython' 
                 login and user.

--- a/test/springpythontest/databaseTransactionTestCases.py
+++ b/test/springpythontest/databaseTransactionTestCases.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -575,7 +575,7 @@ class SQLServerTransactionTestCase(AbstractTransactionTestCase):
             print("""
                 !!! Can't run SQLServerDatabaseTemplateTestCase !!!
 
-                This assumes you have installed pyodbc (http://code.google.com/p/pyodbc/).
+                This assumes you have installed pyodbc (https://code.google.com/p/pyodbc/).
 
                 And then created an SQL Server database for the 'springpython' 
                 login and user.

--- a/test/springpythontest/jms_websphere_mq_test_cases.py
+++ b/test/springpythontest/jms_websphere_mq_test_cases.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/test/springpythontest/org/springframework/springpython/HessianJavaServer.java
+++ b/test/springpythontest/org/springframework/springpython/HessianJavaServer.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2006-2008 SpringSource (http://springsource.com, All Rights Reserved
+ *  Copyright 2006-2008 SpringSource (https://springsource.com, All Rights Reserved
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/test/springpythontest/org/springframework/springpython/Person.java
+++ b/test/springpythontest/org/springframework/springpython/Person.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2006-2008 SpringSource (http://springsource.com, All Rights Reserved
+ *  Copyright 2006-2008 SpringSource (https://springsource.com, All Rights Reserved
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/test/springpythontest/org/springframework/springpython/SampleService.java
+++ b/test/springpythontest/org/springframework/springpython/SampleService.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2006-2008 SpringSource (http://springsource.com, All Rights Reserved
+ *  Copyright 2006-2008 SpringSource (https://springsource.com, All Rights Reserved
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/test/springpythontest/remotingTestCases.py
+++ b/test/springpythontest/remotingTestCases.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/test/springpythontest/remoting_xmlrpc.py
+++ b/test/springpythontest/remoting_xmlrpc.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/test/springpythontest/securityEncodingTestCases.py
+++ b/test/springpythontest/securityEncodingTestCases.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/test/springpythontest/securityLdapTestCases.py
+++ b/test/springpythontest/securityLdapTestCases.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/test/springpythontest/securityProviderTestCases.py
+++ b/test/springpythontest/securityProviderTestCases.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/test/springpythontest/securityUserDetailsTestCases.py
+++ b/test/springpythontest/securityUserDetailsTestCases.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/test/springpythontest/securityVoteTestCases.py
+++ b/test/springpythontest/securityVoteTestCases.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/test/springpythontest/securityWebTestCases.py
+++ b/test/springpythontest/securityWebTestCases.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/test/springpythontest/support/__init__.py
+++ b/test/springpythontest/support/__init__.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/test/springpythontest/support/setupPostGreSQLSpringPython.sql
+++ b/test/springpythontest/support/setupPostGreSQLSpringPython.sql
@@ -1,6 +1,6 @@
 /*
 ######################################################################################
-#   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+#   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/test/springpythontest/support/testSecurityClasses.py
+++ b/test/springpythontest/support/testSecurityClasses.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/test/springpythontest/support/testSupportClasses.py
+++ b/test/springpythontest/support/testSupportClasses.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/test/springpythontest/util_test_cases.py
+++ b/test/springpythontest/util_test_cases.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/test/standalone/pyro_thread_test.py
+++ b/test/standalone/pyro_thread_test.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 ########################################################################
 # This is a stand-alone test, meaning it doesn't run well in automated
-# scenarios. This script exposed bug http://jira.springframework.org/browse/SESPRINGPYTHONPY-99,
+# scenarios. This script exposed bug https://jira.springframework.org/browse/SESPRINGPYTHONPY-99,
 # which showed _PyroThread having a name collisions with python2.6's threading.Thread
 # class. By renaming _PyroThread's self.daemon as self.pyro_daemon, this code
 # now works with python2.6. It was also used to confirm python2.5, and jython2.5.1.FINAL.

--- a/test/standalone/xsd_test_cases.py
+++ b/test/standalone/xsd_test_cases.py
@@ -1,5 +1,5 @@
 """
-   Copyright 2006-2008 SpringSource (http://springsource.com), All Rights Reserved
+   Copyright 2006-2008 SpringSource (https://springsource.com), All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/test_and_package.bash
+++ b/test_and_package.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 ###################################################################################
-#   Copyright 2006-2011 SpringSource (http://springsource.com), All Rights Reserved
+#   Copyright 2006-2011 SpringSource (https://springsource.com), All Rights Reserved
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/xml/schema/context/spring-python-context-1.0.xsd
+++ b/xml/schema/context/spring-python-context-1.0.xsd
@@ -6,7 +6,7 @@
 		elementFormDefault="qualified"
 		attributeFormDefault="unqualified">
 
-	<xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+	<xsd:import namespace="https://www.w3.org/XML/1998/namespace"/>
 
 	<xsd:annotation>
 		<xsd:documentation><![CDATA[

--- a/xml/schema/context/spring-python-context-1.1.xsd
+++ b/xml/schema/context/spring-python-context-1.1.xsd
@@ -6,7 +6,7 @@
 		elementFormDefault="qualified"
 		attributeFormDefault="unqualified">
 
-	<xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+	<xsd:import namespace="https://www.w3.org/XML/1998/namespace"/>
 
 	<xsd:annotation>
 		<xsd:documentation><![CDATA[

--- a/xml/schema/context/spring-python-pycontainer-context-1.0.xsd
+++ b/xml/schema/context/spring-python-pycontainer-context-1.0.xsd
@@ -6,7 +6,7 @@
 		elementFormDefault="qualified"
 		attributeFormDefault="unqualified">
 
-	<xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+	<xsd:import namespace="https://www.w3.org/XML/1998/namespace"/>
 
 	<xsd:annotation>
 		<xsd:documentation><![CDATA[


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://acegisecurity.org/ (200) with 1 occurrences could not be migrated:  
   ([https](https://acegisecurity.org/) result AnnotatedConnectException).
* [ ] http://acegisecurity.org/guide/springsecurity.html (200) with 1 occurrences could not be migrated:  
   ([https](https://acegisecurity.org/guide/springsecurity.html) result AnnotatedConnectException).
* [ ] http://hessian.caucho.com/ (200) with 1 occurrences could not be migrated:  
   ([https](https://hessian.caucho.com/) result SSLHandshakeException).
* [ ] http://pyro.sourceforge.net/ (200) with 2 occurrences could not be migrated:  
   ([https](https://pyro.sourceforge.net/) result AnnotatedConnectException).
* [ ] http://springpython.webfactional.com (200) with 13 occurrences could not be migrated:  
   ([https](https://springpython.webfactional.com) result SSLHandshakeException).
* [ ] http://www.acegisecurity.org (200) with 1 occurrences could not be migrated:  
   ([https](https://www.acegisecurity.org) result AnnotatedConnectException).
* [ ] http://www.aulinx.de/ (200) with 1 occurrences could not be migrated:  
   ([https](https://www.aulinx.de/) result SSLHandshakeException).
* [ ] http://www.devshed.com/c/a/Python/IRC-on-a-Higher-Level-Concluded/ (200) with 1 occurrences could not be migrated:  
   ([https](https://www.devshed.com/c/a/Python/IRC-on-a-Higher-Level-Concluded/) result SSLHandshakeException).
* [ ] http://www.devshed.com/c/a/Python/IRC-on-a-Higher-Level-Continued/ (200) with 1 occurrences could not be migrated:  
   ([https](https://www.devshed.com/c/a/Python/IRC-on-a-Higher-Level-Continued/) result SSLHandshakeException).
* [ ] http://www.devshed.com/c/a/Python/IRC-on-a-Higher-Level/ (200) with 1 occurrences could not be migrated:  
   ([https](https://www.devshed.com/c/a/Python/IRC-on-a-Higher-Level/) result SSLHandshakeException).
* [ ] http://www.phyast.pitt.edu/~micheles/python/documentation.html (200) with 1 occurrences could not be migrated:  
   ([https](https://www.phyast.pitt.edu/~micheles/python/documentation.html) result ConnectTimeoutException).
* [ ] http://www.positioniseverything.net/ordered-floats.html (200) with 1 occurrences could not be migrated:  
   ([https](https://www.positioniseverything.net/ordered-floats.html) result SSLException).
* [ ] http://www.pygresql.org/ (200) with 1 occurrences could not be migrated:  
   ([https](https://www.pygresql.org/) result SSLHandshakeException).
* [ ] http://www.caucho.com/hessian/test/basic (302) with 1 occurrences could not be migrated:  
   ([https](https://www.caucho.com/hessian/test/basic) result SSLHandshakeException).
* [ ] http://hessian.caucho.com/test/basic (404) with 1 occurrences could not be migrated:  
   ([https](https://hessian.caucho.com/test/basic) result SSLHandshakeException).
* [ ] http://springpython.webfactional.com/schema/context/spring-python-context-1.1.xsd (404) with 16 occurrences could not be migrated:  
   ([https](https://springpython.webfactional.com/schema/context/spring-python-context-1.1.xsd) result SSLHandshakeException).
* [ ] http://springpython.webfactional.com/schema/context/spring-python-pycontainer-context-1.0.xsd (404) with 3 occurrences could not be migrated:  
   ([https](https://springpython.webfactional.com/schema/context/spring-python-pycontainer-context-1.0.xsd) result SSLHandshakeException).
* [ ] http://hessian.caucho.com/test/test (500) with 1 occurrences could not be migrated:  
   ([https](https://hessian.caucho.com/test/test) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://diveintopython.org/power_of_introspection/index.html (302) with 1 occurrences migrated to:  
  /UcONZ/power_of_introspection/index.html ([https](https://diveintopython.org/power_of_introspection/index.html) result IllegalArgumentException).
* [ ] http://www.caucho.com/ (302) with 1 occurrences migrated to:  
  https://www.caucho.com/ ([https](https://www.caucho.com/) result SSLHandshakeException).
* [ ] http://www.yaml.org/ (301) with 1 occurrences migrated to:  
  https://yaml.org ([https](https://www.yaml.org/) result AnnotatedConnectException).
* [ ] http://www.razorvine.net/python/Pyro/ (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://www.razorvine.net/python/Pyro/ ([https](https://www.razorvine.net/python/Pyro/) result ConnectTimeoutException).
* [ ] http://lists.springsource.com/archives/springpython-users/ (UnknownHostException) with 1 occurrences migrated to:  
  https://lists.springsource.com/archives/springpython-users/ ([https](https://lists.springsource.com/archives/springpython-users/) result UnknownHostException).
* [ ] http://lists.springsource.com/listmanager/listinfo/springpython-users (UnknownHostException) with 2 occurrences migrated to:  
  https://lists.springsource.com/listmanager/listinfo/springpython-users ([https](https://lists.springsource.com/listmanager/listinfo/springpython-users) result UnknownHostException).
* [ ] http://s3browse.springsource.com/browse/dist.springframework.org/%s/EXTPY (UnknownHostException) with 1 occurrences migrated to:  
  https://s3browse.springsource.com/browse/dist.springframework.org/%s/EXTPY ([https](https://s3browse.springsource.com/browse/dist.springframework.org/%s/EXTPY) result UnknownHostException).
* [ ] http://style.cleverchimp.com/font_size_intervals/altintervals.html (UnknownHostException) with 1 occurrences migrated to:  
  https://style.cleverchimp.com/font_size_intervals/altintervals.html ([https](https://style.cleverchimp.com/font_size_intervals/altintervals.html) result UnknownHostException).
* [ ] http://www.mark.ac/help (UnknownHostException) with 1 occurrences migrated to:  
  https://www.mark.ac/help ([https](https://www.mark.ac/help) result UnknownHostException).
* [ ] http://xyz (UnknownHostException) with 2 occurrences migrated to:  
  https://xyz ([https](https://xyz) result UnknownHostException).
* [ ] http://book.git-scm.com/index.html (301) with 1 occurrences migrated to:  
  https://book.git-scm.com/index.html ([https](https://book.git-scm.com/index.html) result 404).
* [ ] http://cherrypy.org/wiki/BehindApache (301) with 1 occurrences migrated to:  
  https://cherrypy.org/wiki/BehindApache ([https](https://cherrypy.org/wiki/BehindApache) result 404).
* [ ] http://sourceforge.net/mailarchive/forum.php?forum=springpython-developer (302) with 1 occurrences migrated to:  
  https://sourceforge.net/p/legacy_/mailarchive/forum.php?forum=springpython-developer ([https](https://sourceforge.net/mailarchive/forum.php?forum=springpython-developer) result 404).
* [ ] http://www.irchelp.org/irchelp/rfc/rfc.html (404) with 1 occurrences migrated to:  
  https://www.irchelp.org/irchelp/rfc/rfc.html ([https](https://www.irchelp.org/irchelp/rfc/rfc.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://alistapart.com/ with 1 occurrences migrated to:  
  https://alistapart.com/ ([https](https://alistapart.com/) result 200).
* [ ] http://bugs.jython.org/issue1489 with 1 occurrences migrated to:  
  https://bugs.jython.org/issue1489 ([https](https://bugs.jython.org/issue1489) result 200).
* [ ] http://cherrypy.org with 1 occurrences migrated to:  
  https://cherrypy.org ([https](https://cherrypy.org) result 200).
* [ ] http://cherrypy.org/ with 7 occurrences migrated to:  
  https://cherrypy.org/ ([https](https://cherrypy.org/) result 200).
* [ ] http://code.activestate.com/recipes/533135/ with 1 occurrences migrated to:  
  https://code.activestate.com/recipes/533135/ ([https](https://code.activestate.com/recipes/533135/) result 200).
* [ ] http://en.wikipedia.org/wiki/Dependency_injection with 3 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Dependency_injection ([https](https://en.wikipedia.org/wiki/Dependency_injection) result 200).
* [ ] http://en.wikipedia.org/wiki/Rich_Internet_application with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Rich_Internet_application ([https](https://en.wikipedia.org/wiki/Rich_Internet_application) result 200).
* [ ] http://en.wikipedia.org/wiki/SQL_injection with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/SQL_injection ([https](https://en.wikipedia.org/wiki/SQL_injection) result 200).
* [ ] http://en.wikipedia.org/wiki/Test-driven_development with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Test-driven_development ([https](https://en.wikipedia.org/wiki/Test-driven_development) result 200).
* [ ] http://freenode.net with 1 occurrences migrated to:  
  https://freenode.net ([https](https://freenode.net) result 200).
* [ ] http://grails.org/ with 1 occurrences migrated to:  
  https://grails.org/ ([https](https://grails.org/) result 200).
* [ ] http://martinfowler.com/articles/injection.html with 1 occurrences migrated to:  
  https://martinfowler.com/articles/injection.html ([https](https://martinfowler.com/articles/injection.html) result 200).
* [ ] http://plone.org/ with 2 occurrences migrated to:  
  https://plone.org/ ([https](https://plone.org/) result 200).
* [ ] http://pyyaml.org/ with 1 occurrences migrated to:  
  https://pyyaml.org/ ([https](https://pyyaml.org/) result 200).
* [ ] http://wikidev.net/ (301) with 1 occurrences migrated to:  
  https://sites.google.com/site/wickelandschaft// ([https](https://wikidev.net/) result 200).
* [ ] http://sourceforge.net/projects/mysql-python/ with 1 occurrences migrated to:  
  https://sourceforge.net/projects/mysql-python/ ([https](https://sourceforge.net/projects/mysql-python/) result 200).
* [ ] http://blog.springsource.com/2006/11/28/a-java-configuration-option-for-spring/ (301) with 1 occurrences migrated to:  
  https://spring.io/blog/2006/11/28/a-java-configuration-option-for-spring/ ([https](https://blog.springsource.com/2006/11/28/a-java-configuration-option-for-spring/) result 200).
* [ ] http://tools.ietf.org/html/rfc3280 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc3280 ([https](https://tools.ietf.org/html/rfc3280) result 200).
* [ ] http://uche.ogbuji.net with 2 occurrences migrated to:  
  https://uche.ogbuji.net ([https](https://uche.ogbuji.net) result 200).
* [ ] http://www.dabeaz.com/ply/ with 1 occurrences migrated to:  
  https://www.dabeaz.com/ply/ ([https](https://www.dabeaz.com/ply/) result 200).
* [ ] http://www.example.com with 1 occurrences migrated to:  
  https://www.example.com ([https](https://www.example.com) result 200).
* [ ] http://www.gnu.org/copyleft/gpl.html with 1 occurrences migrated to:  
  https://www.gnu.org/copyleft/gpl.html ([https](https://www.gnu.org/copyleft/gpl.html) result 200).
* [ ] http://www.fourthought.com (301) with 2 occurrences migrated to:  
  https://www.pinkertonpw.com/ ([https](https://www.fourthought.com) result 200).
* [ ] http://www.python.org/ with 1 occurrences migrated to:  
  https://www.python.org/ ([https](https://www.python.org/) result 200).
* [ ] http://www.python.org/dev/peps/pep-0249/ with 1 occurrences migrated to:  
  https://www.python.org/dev/peps/pep-0249/ ([https](https://www.python.org/dev/peps/pep-0249/) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans-2.5.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-2.5.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-2.5.xsd) result 200).
* [ ] http://www.w3.org/2003/07/30-font-size with 1 occurrences migrated to:  
  https://www.w3.org/2003/07/30-font-size ([https](https://www.w3.org/2003/07/30-font-size) result 200).
* [ ] http://www.w3.org/XML/1998/namespace with 3 occurrences migrated to:  
  https://www.w3.org/XML/1998/namespace ([https](https://www.w3.org/XML/1998/namespace) result 200).
* [ ] http://code.google.com/p/pyodbc/ with 2 occurrences migrated to:  
  https://code.google.com/p/pyodbc/ ([https](https://code.google.com/p/pyodbc/) result 301).
* [ ] http://docs.python.org/library/collections.html?highlight=mutableset with 2 occurrences migrated to:  
  https://docs.python.org/library/collections.html?highlight=mutableset ([https](https://docs.python.org/library/collections.html?highlight=mutableset) result 301).
* [ ] http://docs.python.org/library/functions.html with 1 occurrences migrated to:  
  https://docs.python.org/library/functions.html ([https](https://docs.python.org/library/functions.html) result 301).
* [ ] http://docs.python.org/library/httplib.html with 2 occurrences migrated to:  
  https://docs.python.org/library/httplib.html ([https](https://docs.python.org/library/httplib.html) result 301).
* [ ] http://docs.python.org/library/logging.html with 2 occurrences migrated to:  
  https://docs.python.org/library/logging.html ([https](https://docs.python.org/library/logging.html) result 301).
* [ ] http://docs.python.org/library/simplexmlrpcserver.html with 2 occurrences migrated to:  
  https://docs.python.org/library/simplexmlrpcserver.html ([https](https://docs.python.org/library/simplexmlrpcserver.html) result 301).
* [ ] http://docs.python.org/library/ssl.html with 7 occurrences migrated to:  
  https://docs.python.org/library/ssl.html ([https](https://docs.python.org/library/ssl.html) result 301).
* [ ] http://docs.python.org/library/stdtypes.html with 2 occurrences migrated to:  
  https://docs.python.org/library/stdtypes.html ([https](https://docs.python.org/library/stdtypes.html) result 301).
* [ ] http://docs.python.org/library/uuid.html with 1 occurrences migrated to:  
  https://docs.python.org/library/uuid.html ([https](https://docs.python.org/library/uuid.html) result 301).
* [ ] http://docs.python.org/library/xmlrpclib.html with 7 occurrences migrated to:  
  https://docs.python.org/library/xmlrpclib.html ([https](https://docs.python.org/library/xmlrpclib.html) result 301).
* [ ] http://static.springsource.org/spring/docs/1.2.x/api/org/springframework/jdbc/core/JdbcTemplate.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/1.2.x/api/org/springframework/jdbc/core/JdbcTemplate.html ([https](https://static.springsource.org/spring/docs/1.2.x/api/org/springframework/jdbc/core/JdbcTemplate.html) result 301).
* [ ] http://en.wikipedia.org with 1 occurrences migrated to:  
  https://en.wikipedia.org ([https](https://en.wikipedia.org) result 301).
* [ ] http://forum.springsource.org/ (301) with 1 occurrences migrated to:  
  https://forum.spring.io/ ([https](https://forum.springsource.org/) result 301).
* [ ] http://forum.springsource.org/forumdisplay.php?f=45 (301) with 2 occurrences migrated to:  
  https://forum.spring.io/forumdisplay.php?f=45 ([https](https://forum.springsource.org/forumdisplay.php?f=45) result 301).
* [ ] http://jira.springframework.org/browse/SESPRINGPYTHONPY-121 with 1 occurrences migrated to:  
  https://jira.springframework.org/browse/SESPRINGPYTHONPY-121 ([https](https://jira.springframework.org/browse/SESPRINGPYTHONPY-121) result 301).
* [ ] http://jira.springframework.org/browse/SESPRINGPYTHONPY-99 with 1 occurrences migrated to:  
  https://jira.springframework.org/browse/SESPRINGPYTHONPY-99 ([https](https://jira.springframework.org/browse/SESPRINGPYTHONPY-99) result 301).
* [ ] http://jira.springsource.org/ with 1 occurrences migrated to:  
  https://jira.springsource.org/ ([https](https://jira.springsource.org/) result 301).
* [ ] http://www.redhatmagazine.com/2007/09/21/building-a-community-around-your-open-source-project/ (301) with 1 occurrences migrated to:  
  https://magazine.redhat.com/2007/09/21/building-a-community-around-your-open-source-project/ ([https](https://www.redhatmagazine.com/2007/09/21/building-a-community-around-your-open-source-project/) result 301).
* [ ] http://mysql.com/ with 1 occurrences migrated to:  
  https://mysql.com/ ([https](https://mysql.com/) result 301).
* [ ] http://pypi.python.org/pypi with 1 occurrences migrated to:  
  https://pypi.python.org/pypi ([https](https://pypi.python.org/pypi) result 301).
* [ ] http://pypi.python.org/pypi/circuits with 1 occurrences migrated to:  
  https://pypi.python.org/pypi/circuits ([https](https://pypi.python.org/pypi/circuits) result 301).
* [ ] http://pypi.python.org/pypi/cx_Oracle with 1 occurrences migrated to:  
  https://pypi.python.org/pypi/cx_Oracle ([https](https://pypi.python.org/pypi/cx_Oracle) result 301).
* [ ] http://pypi.python.org/pypi/decorator with 1 occurrences migrated to:  
  https://pypi.python.org/pypi/decorator ([https](https://pypi.python.org/pypi/decorator) result 301).
* [ ] http://pypi.python.org/pypi/elementtree with 1 occurrences migrated to:  
  https://pypi.python.org/pypi/elementtree ([https](https://pypi.python.org/pypi/elementtree) result 301).
* [ ] http://pypi.python.org/pypi/pyodbc with 1 occurrences migrated to:  
  https://pypi.python.org/pypi/pyodbc ([https](https://pypi.python.org/pypi/pyodbc) result 301).
* [ ] http://pypi.python.org/pypi/pysqlite/ with 1 occurrences migrated to:  
  https://pypi.python.org/pypi/pysqlite/ ([https](https://pypi.python.org/pypi/pysqlite/) result 301).
* [ ] http://pypi.python.org/pypi/threadpool with 1 occurrences migrated to:  
  https://pypi.python.org/pypi/threadpool ([https](https://pypi.python.org/pypi/threadpool) result 301).
* [ ] http://springsource.com with 105 occurrences migrated to:  
  https://springsource.com ([https](https://springsource.com) result 301).
* [ ] http://www.amk.ca/python/howto/regex/ with 1 occurrences migrated to:  
  https://www.amk.ca/python/howto/regex/ ([https](https://www.amk.ca/python/howto/regex/) result 301).
* [ ] http://www.cherrypy.org with 5 occurrences migrated to:  
  https://www.cherrypy.org ([https](https://www.cherrypy.org) result 301).
* [ ] http://www.cherrypy.org/ with 2 occurrences migrated to:  
  https://www.cherrypy.org/ ([https](https://www.cherrypy.org/) result 301).
* [ ] http://www.linuxtoday.com/news_story.php3?ltsn=2007-10-12-009-26-OS-DV-NT with 1 occurrences migrated to:  
  https://www.linuxtoday.com/news_story.php3?ltsn=2007-10-12-009-26-OS-DV-NT ([https](https://www.linuxtoday.com/news_story.php3?ltsn=2007-10-12-009-26-OS-DV-NT) result 301).
* [ ] http://www.python.org/dev/peps/pep-0249 with 1 occurrences migrated to:  
  https://www.python.org/dev/peps/pep-0249 ([https](https://www.python.org/dev/peps/pep-0249) result 301).
* [ ] http://www.simplythebest.net/ with 1 occurrences migrated to:  
  https://www.simplythebest.net/ ([https](https://www.simplythebest.net/) result 301).
* [ ] http://www.springframework.org with 1 occurrences migrated to:  
  https://www.springframework.org ([https](https://www.springframework.org) result 301).
* [ ] http://www.springsource.org/ with 1 occurrences migrated to:  
  https://www.springsource.org/ ([https](https://www.springsource.org/) result 301).
* [ ] http://www.springsource.org/javaconfig with 1 occurrences migrated to:  
  https://www.springsource.org/javaconfig ([https](https://www.springsource.org/javaconfig) result 301).
* [ ] http://eclipse.org/ with 1 occurrences migrated to:  
  https://eclipse.org/ ([https](https://eclipse.org/) result 302).
* [ ] http://www.springsource.com/download/community?project=Spring%20Python with 2 occurrences migrated to:  
  https://www.springsource.com/download/community?project=Spring%20Python ([https](https://www.springsource.com/download/community?project=Spring%20Python) result 302).
* [ ] http://www.springsource.org/extensions with 1 occurrences migrated to:  
  https://www.springsource.org/extensions ([https](https://www.springsource.org/extensions) result 302).
* [ ] http://s3.amazonaws.com/ with 1 occurrences migrated to:  
  https://s3.amazonaws.com/ ([https](https://s3.amazonaws.com/) result 307).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8001 with 1 occurrences
* http://localhost:8001/ with 2 occurrences
* http://localhost:8002/ with 1 occurrences
* http://localhost:8080 with 1 occurrences
* http://localhost:8080/ with 2 occurrences
* http://localhost:9001/ with 2 occurrences
* http://www.springframework.org/schema/beans with 3 occurrences
* http://www.springframework.org/springpython/schema/objects with 6 occurrences
* http://www.springframework.org/springpython/schema/objects/1.1 with 38 occurrences
* http://www.springframework.org/springpython/schema/pycontainer-components with 11 occurrences
* http://www.w3.org/2001/XMLSchema with 6 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 20 occurrences